### PR TITLE
CLDR-18847 dualOffsetFormat: add examples

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1732,7 +1732,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST relativePeriod draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
 
-<!ELEMENT timeZoneNames ( alias | ( hourFormat*, hoursFormat*, gmtFormat*, gmtZeroFormat*, gmtUnknownFormat*, dualOffset*, regionFormat*, fallbackFormat*, fallbackRegionFormat*, abbreviationFallback*, preferenceOrdering*, singleCountries*, default*, zone*, metazone*, special* ) ) >
+<!ELEMENT timeZoneNames ( alias | ( hourFormat*, hoursFormat*, gmtFormat*, gmtZeroFormat*, gmtUnknownFormat*, dualOffsetFormat*, regionFormat*, fallbackFormat*, fallbackRegionFormat*, abbreviationFallback*, preferenceOrdering*, singleCountries*, default*, zone*, metazone*, special* ) ) >
 <!ATTLIST timeZoneNames draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >
     <!--@METADATA-->
     <!--@DEPRECATED-->
@@ -1788,13 +1788,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST gmtUnknownFormat references CDATA #IMPLIED >
     <!--@METADATA-->
 
-<!ELEMENT dualOffset ( #PCDATA ) >
-<!ATTLIST dualOffset alt NMTOKENS #IMPLIED >
+<!ELEMENT dualOffsetFormat ( #PCDATA ) >
+<!ATTLIST dualOffsetFormat alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
-<!ATTLIST dualOffset draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >
+<!ATTLIST dualOffsetFormat draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >
     <!--@METADATA-->
     <!--@DEPRECATED:true, false-->
-<!ATTLIST dualOffset references CDATA #IMPLIED >
+<!ATTLIST dualOffsetFormat references CDATA #IMPLIED >
     <!--@METADATA-->
 
 <!ELEMENT regionFormat ( #PCDATA ) >

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -2784,7 +2784,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<gmtFormat>GMT{0}</gmtFormat>
 			<gmtZeroFormat>GMT</gmtZeroFormat>
 			<gmtUnknownFormat>GMT+?</gmtUnknownFormat>
-			<dualOffset>{0}/{1}</dualOffset>
+			<dualOffsetFormat>{0}/{1}</dualOffsetFormat>
 			<regionFormat>{0}</regionFormat>
 			<regionFormat type="daylight">{0} (+1)</regionFormat>
 			<regionFormat type="standard">{0} (+0)</regionFormat>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -167,7 +167,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%timeZones" value="(Africa|America|Antarctica|Arctic|Asia|Australia|Atlantic|Europe|Indian|Pacific)(/[A-Za-z_\-]++){1,2}"/>
 		<coverageVariable key="%traditionalCollationLanguages" value="(bn|es|kn|sa)"/>
 		<coverageVariable key="%transformNameTypes" value="(BGN|Numeric|Tone|UNGEGN|x-(Accents|Fullwidth|Halfwidth|Jamo|Pinyin|Publishing))"/>
-		
+
 		<coverageVariable key="%unitDurationTypes" value="duration-(year|month|week|day|hour|minute|second|millisecond)"/>
 		<coverageVariable key="%unitLengths" value="(long|short|narrow)"/>
 		<coverageVariable key="%unitsEnglish" value="(length-fathom|length-furlong|mass-stone|volume-bushel|energy-british-thermal-unit|volume-pint-imperial|volume-cup-imperial|temperature-rankine|mass-slug|pressure-gasoline-energy-density|energy-british-thermal-unit-it|length-rod|length-chain|duration-fortnight)"/>
@@ -231,12 +231,12 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<!-- *********************
 		Temporary overrides to avoid values that were added in a non-submission cycle
-		This avoids a temporary drop in coverage. 
+		This avoids a temporary drop in coverage.
 		Make this empty for submission cycles.
 		********************* -->
-		
+
 		<!--  currently empty -->
-		
+
 		<!-- *********************
 		Modified Basic rules (v41)
 		These contain a mixture of basic and moderate.
@@ -445,7 +445,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/metazone[@type='GMT']/long/standard"/>
 
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/gmtUnknownFormat"/>
-		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/dualOffset"/>
+		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/dualOffsetFormat"/>
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/zone[@type='Etc/UTC']/long/standard"/>
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/zone[@type='Etc/Unknown']/exemplarCity"/>
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/zone[@type='${Target-TimeZones}']/exemplarCity"/>
@@ -578,11 +578,11 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	match="numbers/currencyFormats[@numberSystem='latn']/unitPattern[@count='%anyAttribute']"/>
 
 		<!-- Moved compact decimal/currency formats for latn up from below, chnage base forms to moderate -->
-		
+
 		<coverageLevel	value="modern"		match="numbers/currencyFormats[@numberSystem='latn']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel	value="moderate"	match="numbers/currencyFormats[@numberSystem='latn']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	match="numbers/decimalFormats[@numberSystem='latn']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>		
-		
+		<coverageLevel	value="moderate"	match="numbers/decimalFormats[@numberSystem='latn']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+
 		<!-- non-latn default number systems, standard formats for decimal/currency/percent/etc also at basic per TC 2024-05-08 -->
 
 		<!-- *********************
@@ -651,7 +651,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="basic"		inLanguage="%tibtDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='tibt']/currencyFormatLength/currencyFormat%stdPattern"/>
 		<coverageLevel	value="comprehensive"	    inLanguage="%tibtDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='tibt']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel	value="comprehensive"	inLanguage="%tibtDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='tibt']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
-	
+
 		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts"	match="numbers/decimalFormats[@numberSystem='adlm']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 		<coverageLevel	value="basic"		inScript="%adlmDefaultScripts"	match="numbers/decimalFormats[@numberSystem='adlm']/decimalFormatLength/decimalFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/decimalFormats[@numberSystem='arab']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
@@ -1008,7 +1008,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inTerritory="%islamicCalendarTerritories" value="modern" match="dates/calendars/calendar[@type='islamic']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
 		<coverageLevel inTerritory="JP" value="modern" match="dates/calendars/calendar[@type='japanese']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
 		<coverageLevel inTerritory="TW" value="modern" match="dates/calendars/calendar[@type='roc']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
-		
+
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatDateItems']/greatestDifference[@id='%intervalFormatGDiff']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatTimeItems']/greatestDifference[@id='%intervalFormatGDiff']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatDateItems']/greatestDifference[@id='%intervalFormatGDiff']"/>
@@ -1031,7 +1031,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="moderate" match="characters/nestedBracketReplacement[@bracket='%A']"/>
 		<coverageLevel value="moderate" match="characters/moreInformation"/>
 		<coverageLevel value="moderate" match="characters/parseLenients[@scope='%anyAttribute'][@level='%anyAttribute']/parseLenient[@sample='%anyAttribute']"/>
-		
+
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%anyAttribute'][@count='%anyAttribute']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/days/dayContext[@type='%contextTypes']/dayWidth[@type='short']/day[@type='%dayTypes']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dayPeriods/dayPeriodContext[@type='%anyAlphaNum']/dayPeriodWidth[@type='%allWidths']/dayPeriod[@type='%anyAlphaNum']"/>
@@ -1136,7 +1136,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="modern"		match="numbers/rationalFormats[@numberSystem='latn']/rationalUsage"/>
 		<coverageLevel	value="modern"		match="numbers/rationalFormats[@numberSystem='latn']/integerAndRationalPattern"/>
 		<coverageLevel	value="modern"		match="numbers/rationalFormats[@numberSystem='latn']/integerAndRationalPattern[@alt='%anyAttribute']"/>
-		
+
 		<coverageLevel inScript="%adlmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='adlm']/approximatelySign"/>
 		<coverageLevel inScript="%adlmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='adlm']/exponential"/>
 		<coverageLevel inScript="%adlmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='adlm']/superscriptingExponent"/>
@@ -1147,7 +1147,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inScript="%adlmDefaultScripts" value="modern" match="numbers/rationalFormats[@numberSystem='adlm']/rationalUsage"/>
 		<coverageLevel inScript="%adlmDefaultScripts" value="modern" match="numbers/rationalFormats[@numberSystem='adlm']/integerAndRationalPattern"/>
 		<coverageLevel inScript="%adlmDefaultScripts" value="modern" match="numbers/rationalFormats[@numberSystem='adlm']/integerAndRationalPattern[@alt='%anyAttribute']"/>
-		
+
 		<coverageLevel inLanguage="%arabDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/approximatelySign"/>
 		<coverageLevel inLanguage="%arabDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/exponential"/>
 		<coverageLevel inLanguage="%arabDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/superscriptingExponent"/>
@@ -1505,33 +1505,33 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="numbers/currencyFormats[@numberSystem='latn']/currencyPatternAppendISO"/>
 
 		<!--  make English-specific units (%unitsEnglish) Modern for "en", otherwise Comprehensive -->
-		
+
 		<coverageLevel inLanguage="en" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
 		<coverageLevel inLanguage="en" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/unitPattern[@count='%anyAttribute']"/>
 		<coverageLevel inLanguage="en" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/displayName"/>
 		<coverageLevel inLanguage="en" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/gender"/>
 		<coverageLevel inLanguage="en" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/perUnitPattern"/>
-		
+
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/unitPattern[@count='%anyAttribute']"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/displayName"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/gender"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/perUnitPattern"/>
-		
+
 		<!--  make Japanese-specific units (%unitsJapanese) Modern for "ja" and "en", otherwise Comprehensive.  -->
-		
+
 		<coverageLevel inLanguage="(ja|en)" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
 		<coverageLevel inLanguage="(ja|en)" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/unitPattern[@count='%anyAttribute']"/>
 		<coverageLevel inLanguage="(ja|en)" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/displayName"/>
 		<coverageLevel inLanguage="(ja|en)" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/gender"/>
 		<coverageLevel inLanguage="(ja|en)" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/perUnitPattern"/>
-		
+
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/unitPattern[@count='%anyAttribute']"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/displayName"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/gender"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/perUnitPattern"/>
-		
+
 		<!-- Other Units, all locales -->
 
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
@@ -1539,16 +1539,16 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/displayName"/>
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/gender"/>
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/perUnitPattern"/>
-		
+
 		<!-- Compound units (all locales) -->
-		
+
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/compoundUnitPattern1[@count='%anyAttribute'][@gender='%anyAttribute'][@case='%anyAttribute']"/>
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/compoundUnitPattern1[@count='%anyAttribute'][@gender='%anyAttribute']"/>
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/compoundUnitPattern1[@count='%anyAttribute'][@case='%anyAttribute']"/>
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/compoundUnitPattern1[@count='%anyAttribute']"/>
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/unitPrefixPattern"/>
 
-		
+
 		<!--  END Other Units -->
 
 		<coverageLevel value="modern" match="localeDisplayNames/types/type[@key='calendar'][@type='%calendarType80'][@scope='%A']"/>

--- a/docs/site/translation/time-zones-and-city-names.md
+++ b/docs/site/translation/time-zones-and-city-names.md
@@ -39,6 +39,7 @@ The following special patterns are used in formatting timezones.
 | regionFormat-standard | {0} Standard Time<br /> *or*<br /> { COUNTRY } Standard Time / { CITY } Standard Time | Bolivia Standard Time |  |   |
 | regionFormat-daylight | {0} Daylight Time<br /> *or*<br /> { COUNTRY } Daylight Time / { CITY } Daylight Time | Bolivia Daylight Time |  |   |
 | fallbackFormat | {1} ({0})<br /> *or*<br /> { METAZONE_NAME } ({ CITY }) | Central Time  ( Cancun ) | **Metazone Name with Location Pattern.** This field is usually not translated. This field to control the formatting of ambiguous metazone name name. When a set of metazone's generic names are shared by multiple different zones and GMT offset at the given time in a zone is different from other zones using the same metazone, this format pattern is used to distinguish the zone from others. In the pattern, {0} will be replaced by location name (either country or city) and {1} will be replaced with the metazone's name.      |  |
+| dualOffsetFormat | {0}/{1} | `GMT+3/+4` | **Dual Offset Pattern** Modify this pattern if a standard and daylight offset need to have different punctuation or spacing | |
 
 ## City Names
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -2589,7 +2589,7 @@ public class ExampleGenerator {
                                                     (int) tm_mins));
                 }
             }
-        } else if (parts.getElement(-1).equals("dualOffset")) {
+        } else if (parts.getElement(-1).equals("dualOffsetFormat")) {
             result = handleDualOffset(parts, parts.toString(), value, examples);
         }
         examples.add(result);
@@ -3901,7 +3901,7 @@ public class ExampleGenerator {
 
     private String handleDualOffset(
             XPathParts parts, String xpath, String value, List<String> examples) {
-        // dualOffset {0}/{1}
+        // dualOffsetFormat {0}/{1}
         // use placeholder samples
         if (value == null || value.isEmpty()) return null;
         Map<String, PlaceholderInfo> dualMap = PatternPlaceholders.getInstance().get(xpath);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -76,6 +76,8 @@ import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PathDescription;
 import org.unicode.cldr.util.PatternCache;
+import org.unicode.cldr.util.PatternPlaceholders;
+import org.unicode.cldr.util.PatternPlaceholders.PlaceholderInfo;
 import org.unicode.cldr.util.PluralSamples;
 import org.unicode.cldr.util.Rational;
 import org.unicode.cldr.util.Rational.FormatStyle;
@@ -2587,6 +2589,8 @@ public class ExampleGenerator {
                                                     (int) tm_mins));
                 }
             }
+        } else if (parts.getElement(-1).equals("dualOffset")) {
+            result = handleDualOffset(parts, parts.toString(), value, examples);
         }
         examples.add(result);
     }
@@ -3875,6 +3879,15 @@ public class ExampleGenerator {
             gmtFormat =
                     setBackground(cldrFile.getWinningValue("//ldml/dates/timeZoneNames/gmtFormat"));
         }
+        String hourString = getHourString(gmtHourString, hours, minutes);
+        if (hoursBackground) {
+            hourString = setBackground(hourString);
+        }
+        String result = format(gmtFormat, hourString);
+        return result;
+    }
+
+    private String getHourString(String gmtHourString, int hours, int minutes) {
         String[] plusMinus = gmtHourString.split(";");
 
         SimpleDateFormat dateFormat =
@@ -3883,11 +3896,24 @@ public class ExampleGenerator {
         calendar.set(1999, 9, 27, Math.abs(hours), minutes, 0); // 1999-09-13 13:25:59
         Date sample = calendar.getTime();
         String hourString = dateFormat.format(sample);
-        if (hoursBackground) {
-            hourString = setBackground(hourString);
+        return hourString;
+    }
+
+    private String handleDualOffset(
+            XPathParts parts, String xpath, String value, List<String> examples) {
+        // dualOffset {0}/{1}
+        // use placeholder samples
+        if (value == null || value.isEmpty()) return null;
+        Map<String, PlaceholderInfo> dualMap = PatternPlaceholders.getInstance().get(xpath);
+        if (dualMap == null) {
+            throw new IllegalArgumentException("Could not load placeholders for " + xpath);
         }
-        String result = format(gmtFormat, hourString);
-        return result;
+        final String sampleWithExamples = PatternPlaceholders.replaceExamples(value, dualMap);
+        final String hourText = setBackground(sampleWithExamples);
+        final String gmtFormat = cldrFile.getWinningValue("//ldml/dates/timeZoneNames/gmtFormat");
+        if (gmtFormat == null || gmtFormat.isEmpty()) return null;
+        final String formattedWithGmt = gmtFormat.replace("{0}", hourText); // GMT{0} -> GMT+3/+4
+        return formattedWithGmt;
     }
 
     private String getMZTimeFormat() {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1667,6 +1667,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                                     "Region Format - Daylight")
                                             .put("gmtFormat", "GMT Format")
                                             .put("hourFormat", "GMT Hours/Minutes Format")
+                                            .put("dualOffsetFormat", "Dual Standard/Daylight Format")
                                             .put("gmtZeroFormat", "GMT Zero Format")
                                             .put("gmtUnknownFormat", "GMT Unknown Format")
                                             .put("fallbackFormat", "Location Fallback Format")
@@ -1680,6 +1681,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                             "hourFormat",
                                             "gmtZeroFormat",
                                             "gmtUnknownFormat",
+                                            "dualFormat",
                                             "fallbackFormat");
 
                             if (fieldOrder.contains(source)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1681,7 +1681,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                             "hourFormat",
                                             "gmtZeroFormat",
                                             "gmtUnknownFormat",
-                                            "dualFormat",
+                                            "dualOffsetFormat",
                                             "fallbackFormat");
 
                             if (fieldOrder.contains(source)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PatternPlaceholders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PatternPlaceholders.java
@@ -6,6 +6,7 @@ import com.ibm.icu.text.Transform;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.util.RegexLookup.Merger;
 
@@ -62,6 +63,15 @@ public class PatternPlaceholders {
         @Override
         public String toString() {
             return "{" + name + "}, e.g. “" + example + "”";
+        }
+
+        /**
+         * @param placeholder the example placeholder such as {0}
+         * @param pattern the string such as "Language: {0}"
+         * @return the pattern with the placeholder replaced with this example
+         */
+        public String replaceExample(String placeholder, String pattern) {
+            return pattern.replace(placeholder, this.example);
         }
     }
 
@@ -164,5 +174,17 @@ public class PatternPlaceholders {
         // "finalize" to the lookup.
         final PlaceholderData map = patternPlaceholders.get(path);
         return map == null ? PlaceholderStatus.DISALLOWED : map.status;
+    }
+
+    /**
+     * @param pattern the pattern string such as "Language: {0}"
+     * @param map the map such as returned from {@link #get(String)}
+     * @return the pattern with the placeholder replaced with all examples
+     */
+    public static String replaceExamples(String pattern, Map<String, PlaceholderInfo> map) {
+        for (Entry<String, PlaceholderInfo> e : map.entrySet()) {
+            pattern = e.getValue().replaceExample(e.getKey(), pattern);
+        }
+        return pattern;
     }
 }

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptions.md
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptions.md
@@ -356,7 +356,7 @@ The pattern used to compose generic fallback time zone names, such as 'Germany T
 
 ###
 
-- `dates/timeZoneNames/(fallback|fallbackRegion|gmtZero|gmtUnknown|gmt|hour|region)Format`
+- `dates/timeZoneNames/(fallback|fallbackRegion|gmtZero|gmtUnknown|gmt|hour|region|dualOffset)Format`
 
 The {1} pattern used to compose time zone names. Note: before translating, be sure to read [Time Zone City Names].
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
@@ -155,7 +155,7 @@
 
 ^//ldml/dates/timeZoneNames/fallbackFormat ; {1}=METAZONE Pacific Time; {0}=CITY_OR_COUNTRY Los Angeles
 ^//ldml/dates/timeZoneNames/gmtFormat ; {0}=HOURS_FROM_GMT +3
-^//ldml/dates/timeZoneNames/dualOffset ; {0}=STANDARD_OFFSET +3; {1}=DAYLIGHT_OFFSET +4
+^//ldml/dates/timeZoneNames/dualOffsetFormat ; {0}=STANDARD_OFFSET +3; {1}=DAYLIGHT_OFFSET +4
 ^//ldml/dates/timeZoneNames/regionFormat ; {0}=COUNTRY_OR_CITY Canada
 
 ^//ldml/listPatterns/listPattern/listPatternPart\[@type="2"] ; {0}=ITEM1 Apples ; {1}=ITEM2 Oranges


### PR DESCRIPTION
- patch to https://github.com/unicode-org/cldr/pull/5558
- also, add some mechanism for easily applying placeholder examples
- also rename dualOffset to `dualOffsetFormat` for consistency with others
- also add translator docs
- also update pathheader

CLDR-18847

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
